### PR TITLE
security: sanitize TAP.conf — remove real DB passwords

### DIFF
--- a/TAP.conf
+++ b/TAP.conf
@@ -1,7 +1,11 @@
 
 #  NexsciTAP Configuration
 #  -----------------------
-#  One nexsciTAP config file can provide access to multiple DBMSs and DBMS instances.  
+#  WARNING: This file is an EXAMPLE template only. Never commit real database
+#  credentials. Copy this file to a location outside the repository, set real
+#  Password= values there, and point your service/tooling at that private copy.
+#
+#  One nexsciTAP config file can provide access to multiple DBMSs and DBMS instances.
 #  So one TAP query might access an Oracle server and the next an SQLite table.  
 #  This config file supports three such instances.
 
@@ -73,7 +77,7 @@
     DBMS=oracle
     ServerName=exodev1
     UserID=exo_tap
-    Password=tye776_py438
+    Password=XXXXXXXXXXXX   #  Placeholder — do NOT commit real credentials.
     INFOMSG=''              #  This parameter is currently only used by
                             #  Exoplanet Archive as additional text in
                             #  error messages.
@@ -83,7 +87,7 @@
     DBMS=oracle
     ServerName=koaops1
     UserID=koa_tap
-    Password=anHSBK6dgw
+    Password=XXXXXXXXXXXX   #  Placeholder — do NOT commit real credentials.
 
     ACCESS_TBL=koa_access  #  For KOA and NEID, there are a set of seven
     USERS_TBL=koa_users    #  additional database-related parameters


### PR DESCRIPTION
## Summary

- Restores `XXXXXXXXXXXX` placeholders for the `exo_tap` and `koa_tap` Oracle passwords in `TAP.conf`.
- Adds a warning header stating that `TAP.conf` is an example template and real credentials must never be committed.

## Background

Real Oracle credentials were committed to `TAP.conf` in [489609d](../commit/489609d) (2024-01-24), when the single-DBMS example config was expanded into the multi-instance template. Prior to that commit the file had always used `tap_user` / `XXXXXXXXXXXX` placeholders, and `main` still does. The leak is limited to `develop` (and branches off it).

The two exposed passwords were for:
- `[ORACLE_EXODEV]` → `exo_tap` on `exodev1`
- `[ORACLE_KOA]` → `koa_tap` on `koaops1`

## Scope of this PR

This PR only sanitizes the **working tree on `develop`**. It does **not** rewrite git history — the old blobs are still reachable via `git log`, forks, and the GitHub REST API.

Full remediation also requires, outside this PR:

1. **Rotate both Oracle accounts** (`exo_tap`, `koa_tap`). _In progress._
2. **Rewrite history** on `develop` (e.g. `git filter-repo --replace-text`) and force-push, after coordinating with anyone tracking the branch. GitHub may retain cached blobs briefly even after rewrite.
3. **Audit DB logs** on `exodev1` and `koaops1` for connections from `exo_tap` / `koa_tap` since 2024-01-24, in case the creds were picked up by a crawler/fork.

## Test plan

- [ ] Confirm `TAP.conf` parses with placeholder passwords in a dev environment (service will fail to connect, as expected, until real creds are supplied out-of-band).
- [ ] Confirm no other tracked file in the repo contains the removed passwords: `git grep -i 'tye776_py438\|anHSBK6dgw'` returns nothing.
- [ ] Verify maintainers have rotated both Oracle service accounts before merging (so this PR's diff — which exposes the previously-leaked values — does not re-expose live credentials).

🤖 Generated with [Claude Code](https://claude.com/claude-code)