### PR TITLE
Security/hardening

### DIFF
--- a/TAP/propfilter.py
+++ b/TAP/propfilter.py
@@ -12,7 +12,7 @@ import time
 from TAP.writeresult import writeResult
 from TAP.datadictionary import dataDictionary
 from TAP.tablenames import TableNames
-from TAP.tablevalidator import TableValidator
+from TAP.tablevalidator import TableValidator, TableValidationError
 
 
 class propFilter:
@@ -586,6 +586,11 @@ class propFilter:
                                            connectInfo=self.connectInfo,
                                            debug=self.debug)
                 validator.validate(user_tables)
+
+            except TableValidationError:
+                # Re-raise as-is so tap.py can distinguish a table
+                # access rejection (403) from other query errors (400).
+                raise
 
             except Exception as e:
 

--- a/TAP/propfilter.py
+++ b/TAP/propfilter.py
@@ -527,12 +527,28 @@ class propFilter:
 
             except Exception as e:
 
+                # ORA-00942: table inaccessible — raise TableValidationError
+                # so tap.py returns HTTP 403 with a clean message instead of
+                # leaking the raw Oracle error. Oracle-specific.
+                if 'ORA-00942' in str(e):
+                    try:
+                        tables = TableNames().extract_tables(self.query)
+                        tname = tables[0] if tables else 'unknown'
+                    except Exception as tex:
+                        if self.debug:
+                            logging.debug(
+                                f'ORA-00942: table name extraction failed: {str(tex):s}')
+                        tname = 'unknown'
+                    raise TableValidationError(
+                        f"Table '{tname}' is not available for querying. "
+                        f"Use TAP_SCHEMA.tables to see available tables.")
+
                 errmsg = \
                     f'Input query [{self.query:s}] syntax error: {str(e):s}'
 
                 if self.debug:
                     logging.debug('')
-                    logging.debug(f'Exception __parseSql: {str(e):s}')
+                    logging.debug(f'Exception __parseSql__: {str(e):s}')
 
                 self.__encodeSqlerrmsg__(errmsg)
 

--- a/TAP/propfilter.py
+++ b/TAP/propfilter.py
@@ -541,7 +541,7 @@ class propFilter:
                         tname = 'unknown'
                     raise TableValidationError(
                         f"Table '{tname}' is not available for querying. "
-                        f"Use TAP_SCHEMA.tables to see available tables.")
+                        f"Use {self.tap_schema}.{self.tables_table} to see available tables.")
 
                 errmsg = \
                     f'Input query [{self.query:s}] syntax error: {str(e):s}'

--- a/TAP/tablenames.py
+++ b/TAP/tablenames.py
@@ -9,6 +9,8 @@ import sqlparse
 from sqlparse.sql import IdentifierList, Identifier
 from sqlparse.tokens import Keyword, DML
 
+from TAP.tablevalidator import TableValidationError
+
 
 class TableNames:
 
@@ -70,10 +72,18 @@ class TableNames:
         extracted_tables = []
         statements = list(sqlparse.parse(sql))
         for statement in statements:
-            if statement.get_type() != 'UNKNOWN':
-                stream = self.extract_from_part(statement)
-                extracted_tables.append(list(
-                    self.extract_table_identifiers(stream)))
+            # Skip write/DDL only. Previously skipped 'UNKNOWN', which caused
+            # Oracle-dialect queries (ROWNUM etc.) to bypass table validation.
+            if statement.get_type() not in (
+                    'INSERT', 'UPDATE', 'DELETE',
+                    'CREATE', 'DROP', 'ALTER'):
+                try:
+                    stream = self.extract_from_part(statement)
+                    extracted_tables.append(list(
+                        self.extract_table_identifiers(stream)))
+                except Exception:
+                    # Cannot verify table access — reject rather than pass through.
+                    raise Exception('Query parsing failed. Unable to verify table access.')
         tables = list(itertools.chain(*extracted_tables))
 
         for idx, _ in enumerate(tables):

--- a/TAP/tablenames.py
+++ b/TAP/tablenames.py
@@ -9,8 +9,6 @@ import sqlparse
 from sqlparse.sql import IdentifierList, Identifier
 from sqlparse.tokens import Keyword, DML
 
-from TAP.tablevalidator import TableValidationError
-
 
 class TableNames:
 
@@ -50,7 +48,7 @@ class TableNames:
                         ['ORDER', 'ORDER BY', 'GROUP', 'GROUP BY',
                          'BY', 'HAVING', 'LIMIT', 'OFFSET']:
                     from_seen = False
-                    StopIteration
+                    return
                 else:
                     yield item
             if item.ttype is Keyword and item.value.upper() == 'FROM':
@@ -81,9 +79,9 @@ class TableNames:
                     stream = self.extract_from_part(statement)
                     extracted_tables.append(list(
                         self.extract_table_identifiers(stream)))
-                except Exception:
+                except Exception as e:
                     # Cannot verify table access — reject rather than pass through.
-                    raise Exception('Query parsing failed. Unable to verify table access.')
+                    raise Exception('Query parsing failed. Unable to verify table access.') from e
         tables = list(itertools.chain(*extracted_tables))
 
         for idx, _ in enumerate(tables):

--- a/TAP/tablevalidator.py
+++ b/TAP/tablevalidator.py
@@ -72,7 +72,8 @@ class TableValidator:
     def validate(self, table_names):
 
         if not table_names:
-            raise Exception('No table names to validate.')
+            # Empty list means extraction failed — reject rather than pass through.
+            raise Exception('No table names found in query. Unable to verify table access.')
 
         for tname in table_names:
             tname_lower = tname.strip().lower()

--- a/TAP/tablevalidator.py
+++ b/TAP/tablevalidator.py
@@ -6,6 +6,15 @@
 import logging
 
 
+class TableValidationError(Exception):
+    """
+    Raised when an ADQL query references a table that is not registered
+    in TAP_SCHEMA. Distinct from a generic Exception so callers can
+    return HTTP 403 (access denied) rather than HTTP 400 (bad request).
+    """
+    pass
+
+
 class TableValidator:
     """
     Validates that table names in an ADQL query are registered in
@@ -89,7 +98,7 @@ class TableValidator:
                 if tname_lower in self.allowed_bare:
                     continue
 
-            raise Exception(
+            raise TableValidationError(
                 f'Table \'{tname}\' is not available for querying. '
                 f'Use TAP_SCHEMA.tables to see available tables.')
 

--- a/TAP/tablevalidator.py
+++ b/TAP/tablevalidator.py
@@ -4,6 +4,7 @@
 
 
 import logging
+import re
 
 
 class TableValidationError(Exception):
@@ -107,3 +108,107 @@ class TableValidator:
             logging.debug('')
             logging.debug(
                 f'TableValidator: all tables validated: {table_names}')
+
+    # DML/DDL keywords that must never appear in a TAP query.
+    # TAP is a read-only protocol (IVOA TAP 1.1).  The ADQL translator
+    # already rejects non-SELECT at the parser level, but this check
+    # runs before ADQL translation as an additional layer of defense.
+    _FORBIDDEN_RE = re.compile(
+        r'\b('
+        r'INSERT|UPDATE|DELETE|DROP|CREATE|ALTER|TRUNCATE|'
+        r'EXEC|EXECUTE|GRANT|REVOKE|COMMIT|ROLLBACK|MERGE|'
+        r'CALL|DECLARE|SET\b\s|BEGIN|'
+        r'INTO\s+OUTFILE|LOAD\s+DATA'
+        r')\b',
+        re.IGNORECASE
+    )
+
+    # Oracle-specific functions that should never be called through TAP.
+    # These are dangerous even in a SELECT context: UTL_HTTP enables SSRF,
+    # UTL_FILE enables filesystem access, DBMS_SQL enables dynamic SQL.
+    _DANGEROUS_FUNCTIONS_RE = re.compile(
+        r'\b('
+        r'UTL_HTTP|UTL_TCP|UTL_SMTP|UTL_FILE|UTL_INADDR|'
+        r'HTTPURITYPE|DBMS_LDAP|DBMS_SQL|DBMS_SCHEDULER|'
+        r'DBMS_JOB|DBMS_METADATA|DBMS_XMLGEN|'
+        r'SYS_CONTEXT|XMLTYPE'
+        r')\b',
+        re.IGNORECASE
+    )
+
+    # Oracle system catalog views and tables that should never be
+    # referenced in a TAP query.  The TableValidator.validate() method
+    # already blocks these (they are not in TAP_SCHEMA), but this is
+    # an additional layer that catches them before any database
+    # connection is made.  Added after an external vulnerability report
+    # used ALL_USERS to enumerate Oracle accounts via UNION ALL bypass.
+    _SYSTEM_OBJECTS_RE = re.compile(
+        r'\b('
+        r'ALL_USERS|DBA_USERS|ALL_TAB_PRIVS|ALL_TAB_COLUMNS|'
+        r'ALL_TABLES|ALL_OBJECTS|ALL_SOURCE|ALL_VIEWS|'
+        r'DBA_TAB_PRIVS|DBA_SYS_PRIVS|DBA_ROLE_PRIVS|'
+        r'DBA_TABLES|DBA_OBJECTS|DBA_SOURCE|DBA_VIEWS|'
+        r'USER_TABLES|USER_TAB_PRIVS|USER_SYS_PRIVS|'
+        r'USER_OBJECTS|USER_SOURCE|USER_ROLE_PRIVS|'
+        r'V\$SESSION|V\$INSTANCE|V\$DATABASE|V\$PARAMETER|'
+        r'INFORMATION_SCHEMA|PG_CATALOG|PG_TABLES|PG_ROLES'
+        r')\b',
+        re.IGNORECASE
+    )
+
+    @staticmethod
+    def validate_statement(query, debug=False):
+        """Reject queries containing DML, DDL, or dangerous Oracle functions.
+
+        TAP is a read-only protocol.  This method blocks statement types
+        and function calls that should never appear in a TAP query,
+        regardless of whether the database user has the privileges to
+        execute them.  This is defense-in-depth: even if database
+        privileges are misconfigured, the application layer rejects
+        the query before it reaches the DBMS.
+
+        Raises Exception if the query contains forbidden content.
+        """
+
+        # Semicolons indicate statement stacking.  TAP accepts a single
+        # statement per request.  Reject before any other check so that
+        # chained statements cannot bypass keyword scanning.
+        if ';' in query:
+            if debug:
+                logging.debug(
+                    'TableValidator: rejected semicolon (statement stacking)')
+            raise Exception(
+                'Query rejected: semicolons are not permitted. '
+                'TAP accepts a single statement per request.')
+
+        forbidden = TableValidator._FORBIDDEN_RE.search(query)
+        if forbidden:
+            keyword = forbidden.group(1).upper()
+            if debug:
+                logging.debug(
+                    f'TableValidator: rejected forbidden keyword: {keyword}')
+            raise Exception(
+                f'Query rejected: \'{keyword}\' statements are not '
+                f'permitted. TAP only supports SELECT queries.')
+
+        dangerous = TableValidator._DANGEROUS_FUNCTIONS_RE.search(query)
+        if dangerous:
+            func = dangerous.group(1).upper()
+            if debug:
+                logging.debug(
+                    f'TableValidator: rejected dangerous function: {func}')
+            raise Exception(
+                f'Query rejected: \'{func}\' is not permitted in '
+                f'TAP queries.')
+
+        system_obj = TableValidator._SYSTEM_OBJECTS_RE.search(query)
+        if system_obj:
+            obj = system_obj.group(1).upper()
+            if debug:
+                logging.debug(
+                    f'TableValidator: rejected system catalog '
+                    f'reference: {obj}')
+            raise Exception(
+                f'Query rejected: \'{obj}\' is a system catalog '
+                f'and is not available for querying. '
+                f'Use TAP_SCHEMA.tables to see available tables.')

--- a/TAP/tablevalidator.py
+++ b/TAP/tablevalidator.py
@@ -102,7 +102,7 @@ class TableValidator:
 
             raise TableValidationError(
                 f'Table \'{tname}\' is not available for querying. '
-                f'Use TAP_SCHEMA.tables to see available tables.')
+                f'Use {self.tap_schema}.{self.tables_table} to see available tables.')
 
         if self.debug:
             logging.debug('')
@@ -167,6 +167,11 @@ class TableValidator:
         privileges are misconfigured, the application layer rejects
         the query before it reaches the DBMS.
 
+        Scanning runs on raw query text before ADQL parsing, so
+        forbidden keywords inside quoted string values will also be
+        rejected.  This is by design: blocking a rare legitimate
+        query is safer than allowing a real attack through.
+
         Raises Exception if the query contains forbidden content.
         """
 
@@ -183,7 +188,7 @@ class TableValidator:
 
         forbidden = TableValidator._FORBIDDEN_RE.search(query)
         if forbidden:
-            keyword = forbidden.group(1).upper()
+            keyword = forbidden.group(1).strip().upper()
             if debug:
                 logging.debug(
                     f'TableValidator: rejected forbidden keyword: {keyword}')
@@ -208,7 +213,5 @@ class TableValidator:
                 logging.debug(
                     f'TableValidator: rejected system catalog '
                     f'reference: {obj}')
-            raise Exception(
-                f'Query rejected: \'{obj}\' is a system catalog '
-                f'and is not available for querying. '
-                f'Use TAP_SCHEMA.tables to see available tables.')
+            raise TableValidationError(
+                f'Table \'{obj}\' is not available for querying.')

--- a/TAP/tap.py
+++ b/TAP/tap.py
@@ -1671,6 +1671,10 @@ class Tap:
 
                 if(self.tapcontext == 'async'):
 
+                    # errcode not passed: UWS async job status has no HTTP
+                    # status field; TAP 1.1 §3.3 requires HTTP 200 for async
+                    # error retrieval regardless of whether this job's error
+                    # is a 403 (blocked table) or 400 (bad request).
                     self.__writeAsyncError__(str(e), self.statuspath,
                                              self.statdict, self.param)
 
@@ -1728,6 +1732,10 @@ class Tap:
 
                 if(self.tapcontext == 'async'):
 
+                    # errcode not passed: UWS async job status has no HTTP
+                    # status field; TAP 1.1 §3.3 requires HTTP 200 for async
+                    # error retrieval regardless of whether this job's error
+                    # is a 403 (blocked table) or 400 (bad request).
                     self.__writeAsyncError__(str(e), self.statuspath,
                                              self.statdict, self.param)
                 else:

--- a/TAP/tap.py
+++ b/TAP/tap.py
@@ -5,6 +5,7 @@
 import os
 import sys
 import fcntl
+import html
 
 import logging
 
@@ -27,7 +28,8 @@ from TAP.tapquery import tapQuery
 from TAP.configparam import configParam
 from TAP.propfilter import propFilter
 from TAP.tablenames import TableNames
-from TAP.vositables import vosiTables 
+from TAP.vositables import vosiTables
+from TAP.tablevalidator import TableValidationError
 
 
 class Tap:
@@ -148,6 +150,20 @@ class Tap:
 
 
     def __init__(self, **kwargs):
+
+        # Wrap all init in __run__ so any uncaught startup exception
+        # (e.g. missing TAP.ini in configparam) returns a proper VOTable
+        # 500 instead of leaking raw text or 'WEB' into the HTTP response.
+        try:
+            self.__run__(**kwargs)
+        except Exception as e:
+            self.__printError__('votable', html.escape(str(e)), errcode='500')
+
+
+    def __run__(self, **kwargs):
+
+        self.infomsg = ''
+        self.dbtable = ''
 
         #
         # { tap.init()
@@ -1648,13 +1664,18 @@ class Tap:
 
                 self.phase = 'ERROR'
 
+                # TableValidationError means the query referenced a table
+                # not in TAP_SCHEMA — access denied (403). All other errors
+                # are bad requests (400).
+                errcode = '403' if isinstance(e, TableValidationError) else '400'
+
                 if(self.tapcontext == 'async'):
 
                     self.__writeAsyncError__(str(e), self.statuspath,
                                              self.statdict, self.param)
 
                 else:
-                    self.__printError__(self.format, str(e), errcode='400')
+                    self.__printError__(self.format, str(e), errcode=errcode)
             #
             # } end tapquery
             #
@@ -1700,12 +1721,17 @@ class Tap:
                 self.phase = 'ERROR'
                 self.errmsg = str(e)
 
+                # TableValidationError means the query referenced a table
+                # not in TAP_SCHEMA — access denied (403). All other errors
+                # are bad requests (400).
+                errcode = '403' if isinstance(e, TableValidationError) else '400'
+
                 if(self.tapcontext == 'async'):
 
                     self.__writeAsyncError__(str(e), self.statuspath,
                                              self.statdict, self.param)
                 else:
-                    self.__printError__(self.format, str(e), errcode='400')
+                    self.__printError__(self.format, str(e), errcode=errcode)
             #
             # } end propfilter
             #
@@ -2492,6 +2518,11 @@ class Tap:
 
 
     def __writeAsyncError__(self, errmsg, statuspath, statdict, param, **kwargs):
+
+        # errcode is not accepted here by design: DALI 1.1 §4.2 requires that
+        # async error documents be returned with HTTP 200 when accessed via
+        # /async/<jobid>/error. The 403 vs 400 distinction only applies to
+        # synchronous responses and is handled in __printError__ at the call sites.
 
         #
         # {

--- a/TAP/tap.py
+++ b/TAP/tap.py
@@ -162,7 +162,10 @@ class Tap:
         try:
             self.__run__(**kwargs)
         except Exception as e:
-            self.__printError__('votable', str(e), errcode='500')
+            logging.error(f'Startup failure: {str(e)}')
+            self.__printError__('votable',
+                                'Internal server error during startup.',
+                                errcode='500')
 
 
     def __run__(self, **kwargs):

--- a/TAP/tap.py
+++ b/TAP/tap.py
@@ -151,19 +151,21 @@ class Tap:
 
     def __init__(self, **kwargs):
 
+        # Required by __printError__ — initialize before __run__ so they
+        # exist even if __run__ throws on its first line.
+        self.infomsg = ''
+        self.dbtable = ''
+
         # Wrap all init in __run__ so any uncaught startup exception
         # (e.g. missing TAP.ini in configparam) returns a proper VOTable
         # 500 instead of leaking raw text or 'WEB' into the HTTP response.
         try:
             self.__run__(**kwargs)
         except Exception as e:
-            self.__printError__('votable', html.escape(str(e)), errcode='500')
+            self.__printError__('votable', str(e), errcode='500')
 
 
     def __run__(self, **kwargs):
-
-        self.infomsg = ''
-        self.dbtable = ''
 
         #
         # { tap.init()
@@ -1482,12 +1484,13 @@ class Tap:
         try:
             TableValidator.validate_statement(query_adql, debug=self.debug)
         except Exception as e:
+            errcode = '403' if isinstance(e, TableValidationError) else '400'
             if(self.tapcontext == 'async'):
                 self.phase = 'ERROR'
                 self.__writeAsyncError__(str(e), self.statuspath,
                                          self.statdict, self.param)
             else:
-                self.__printError__(self.format, str(e), errcode='400')
+                self.__printError__(self.format, str(e), errcode=errcode)
             return
 
         try:
@@ -2508,12 +2511,14 @@ class Tap:
             print('<RESOURCE type="results">')
             print('<INFO name="QUERY_STATUS" value="ERROR">')
 
-            print(errmsg)
+            # Escape for XML: error messages may contain query-derived
+            # content (table names, ADQL fragments) with <, >, &, or quotes.
+            print(html.escape(errmsg))
 
-            if(len(self.infomsg) > 0):                                         
-                if(self.infomsg[-1] == '?'):                                   
-                    print(self.infomsg + 'dbtable=' + self.dbtable)            
-                else:                                                          
+            if(len(self.infomsg) > 0):
+                if(self.infomsg[-1] == '?'):
+                    print(self.infomsg + 'dbtable=' + html.escape(self.dbtable))
+                else:
                     print(self.infomsg)                                        
 
             print('</INFO>')
@@ -2524,11 +2529,11 @@ class Tap:
             print("Content-type: text/plain\r")
             print("\r")
             print (errmsg)
-                     
-            if(len(self.infomsg) > 0):                                         
-                if(self.infomsg[-1] == '?'):                                   
-                    print(self.infomsg + 'dbtable=' + self.dbtable)            
-                else:                                                          
+
+            if(len(self.infomsg) > 0):
+                if(self.infomsg[-1] == '?'):
+                    print(self.infomsg + 'dbtable=' + self.dbtable)
+                else:
                     print(self.infomsg)                                        
                    
 
@@ -2817,30 +2822,11 @@ class Tap:
 
 
         #
-        # Encode query to escape '<' and '>'
+        # Escape query for XML embedding (handles &, <, >, and quotes).
+        # Replaces manual < > replacement that did not escape &.
         #
 
-        str1 = param['query']
-
-        ind = str1.find('<')
-        while(ind >= 0):
-
-            substr1 = str1[0:ind]
-            substr2 = str1[ind + 1:]
-
-            str1 = substr1 + '&lt;' + substr2
-            ind = str1.find('<')
-
-        ind = str1.find('>')
-        while(ind >= 0):
-
-            substr1 = str1[0:ind]
-            substr2 = str1[ind + 1:]
-
-            str1 = substr1 + '&gt;' + substr2
-            ind = str1.find('>')
-
-        fp.write(f'        <uws:parameter id="query">{str1:s}')
+        fp.write(f'        <uws:parameter id="query">{html.escape(param["query"]):s}')
         fp.write('        </uws:parameter>\n')
 
         fp.write('    </uws:parameters>\n')
@@ -2855,7 +2841,7 @@ class Tap:
         elif(phase.lower() == 'error'):
 
             fp.write('    <uws:errorSummary type="transient" hasDetail="true">\n')
-            fp.write(f'        <uws:message>{errmsg:s}</uws:message>\n')
+            fp.write(f'        <uws:message>{html.escape(errmsg):s}</uws:message>\n')
             fp.write('    </uws:errorSummary>\n')
 
         fp.write('</uws:job>\n')

--- a/TAP/tap.py
+++ b/TAP/tap.py
@@ -29,7 +29,7 @@ from TAP.configparam import configParam
 from TAP.propfilter import propFilter
 from TAP.tablenames import TableNames
 from TAP.vositables import vosiTables
-from TAP.tablevalidator import TableValidationError
+from TAP.tablevalidator import TableValidationError, TableValidator
 
 
 class Tap:
@@ -1473,6 +1473,22 @@ class Tap:
         if self.debug:
             logging.debug('')
             logging.debug(f'ADQL query: {query_adql:s}\n')
+
+        # Reject DML, DDL, and dangerous Oracle functions before any
+        # parsing or translation.  This runs before the ADQL translator
+        # and before any database connection, so it catches malicious
+        # queries at the earliest possible point.
+
+        try:
+            TableValidator.validate_statement(query_adql, debug=self.debug)
+        except Exception as e:
+            if(self.tapcontext == 'async'):
+                self.phase = 'ERROR'
+                self.__writeAsyncError__(str(e), self.statuspath,
+                                         self.statdict, self.param)
+            else:
+                self.__printError__(self.format, str(e), errcode='400')
+            return
 
         try:
             mode = SpatialIndex.HTM

--- a/TAP/tapquery.py
+++ b/TAP/tapquery.py
@@ -14,7 +14,7 @@ import configobj
 from TAP.datadictionary import dataDictionary
 from TAP.writeresult    import writeResult
 from TAP.tablenames     import TableNames
-from TAP.tablevalidator import TableValidator
+from TAP.tablevalidator import TableValidator, TableValidationError
 from TAP.configparam    import configParam
 
 from ADQL.adql import ADQL
@@ -593,6 +593,11 @@ class tapQuery:
                         connectInfo=self.connectInfo,
                         debug=self.debug)
                     validator.validate(user_tables)
+
+                except TableValidationError:
+                    # Re-raise as-is so tap.py can distinguish a table
+                    # access rejection (403) from other query errors (400).
+                    raise
 
                 except Exception as e:
 

--- a/tests/test_tablevalidator.py
+++ b/tests/test_tablevalidator.py
@@ -3,7 +3,7 @@ import sqlite3
 import tempfile
 import unittest
 
-from TAP.tablevalidator import TableValidator
+from TAP.tablevalidator import TableValidator, TableValidationError
 
 
 def _make_db(table_names, schema_name='TAP_SCHEMA', tables_table='tables'):
@@ -74,7 +74,9 @@ class TestTableValidator(unittest.TestCase):
     def test_bare_in_whitelist_unknown_schema_in_query(self):
         """'ps' is whitelisted bare; 'public.ps' has unknown schema — rejected."""
         v = TableValidator(self.conn, connectInfo=self.connectInfo)
-        with self.assertRaises(Exception):
+        # Assert TableValidationError specifically so a revert to generic Exception
+        # would be caught — tap.py relies on this type for 403 vs 400 distinction.
+        with self.assertRaises(TableValidationError):
             v.validate(['public.ps'])
 
     def test_known_schema_bare_table_in_query(self):
@@ -84,7 +86,9 @@ class TestTableValidator(unittest.TestCase):
 
     def test_disallowed_table_raises(self):
         v = TableValidator(self.conn, connectInfo=self.connectInfo)
-        with self.assertRaises(Exception) as ctx:
+        # Assert TableValidationError specifically so a revert to generic Exception
+        # would be caught — tap.py relies on this type for 403 vs 400 distinction.
+        with self.assertRaises(TableValidationError) as ctx:
             v.validate(['pg_catalog.pg_tables'])
         self.assertIn('not available', str(ctx.exception))
 
@@ -94,12 +98,16 @@ class TestTableValidator(unittest.TestCase):
 
     def test_multi_table_one_invalid(self):
         v = TableValidator(self.conn, connectInfo=self.connectInfo)
-        with self.assertRaises(Exception) as ctx:
+        # Assert TableValidationError specifically so a revert to generic Exception
+        # would be caught — tap.py relies on this type for 403 vs 400 distinction.
+        with self.assertRaises(TableValidationError) as ctx:
             v.validate(['ps', 'information_schema.tables', 'stellarhosts'])
         self.assertIn('information_schema.tables', str(ctx.exception))
 
     def test_empty_table_list_raises(self):
         v = TableValidator(self.conn, connectInfo=self.connectInfo)
+        # Empty list is a protocol-level error, not a table access rejection —
+        # generic Exception is correct here (not TableValidationError).
         with self.assertRaises(Exception):
             v.validate([])
 
@@ -113,7 +121,9 @@ class TestTableValidator(unittest.TestCase):
             'pg_catalog.pg_class',
             'EXOFOP.FILES',
         ]:
-            with self.assertRaises(Exception, msg=f'{bad_table} should be blocked'):
+            # Assert TableValidationError specifically so a revert to generic Exception
+            # would be caught — tap.py relies on this type for 403 vs 400 distinction.
+            with self.assertRaises(TableValidationError, msg=f'{bad_table} should be blocked'):
                 v.validate([bad_table])
 
 

--- a/tests/test_tablevalidator.py
+++ b/tests/test_tablevalidator.py
@@ -127,5 +127,135 @@ class TestTableValidator(unittest.TestCase):
                 v.validate([bad_table])
 
 
+class TestValidateStatement(unittest.TestCase):
+    """Tests for the pre-connection validate_statement() static method."""
+
+    def test_clean_select_passes(self):
+        TableValidator.validate_statement("SELECT ra, dec FROM ps WHERE ra > 10")
+
+    def test_select_with_functions_passes(self):
+        TableValidator.validate_statement(
+            "SELECT TOP 10 ra, dec, count(*) FROM ps GROUP BY ra, dec")
+
+    def test_semicolon_rejected(self):
+        with self.assertRaises(Exception) as ctx:
+            TableValidator.validate_statement("SELECT 1; DROP TABLE ps")
+        self.assertIn('semicolon', str(ctx.exception).lower())
+
+    def test_insert_rejected(self):
+        with self.assertRaises(Exception) as ctx:
+            TableValidator.validate_statement("INSERT INTO ps VALUES (1, 2)")
+        self.assertIn('INSERT', str(ctx.exception))
+
+    def test_drop_rejected(self):
+        with self.assertRaises(Exception) as ctx:
+            TableValidator.validate_statement("DROP TABLE ps")
+        self.assertIn('DROP', str(ctx.exception))
+
+    def test_delete_rejected(self):
+        with self.assertRaises(Exception):
+            TableValidator.validate_statement("DELETE FROM ps WHERE ra = 0")
+
+    def test_update_rejected(self):
+        with self.assertRaises(Exception):
+            TableValidator.validate_statement("UPDATE ps SET ra = 0")
+
+    def test_dangerous_function_utl_http(self):
+        with self.assertRaises(Exception) as ctx:
+            TableValidator.validate_statement(
+                "SELECT UTL_HTTP.request('http://evil.com') FROM dual")
+        self.assertIn('UTL_HTTP', str(ctx.exception))
+
+    def test_dangerous_function_dbms_sql(self):
+        with self.assertRaises(Exception):
+            TableValidator.validate_statement(
+                "SELECT DBMS_SQL.execute(1) FROM dual")
+
+    def test_dangerous_function_sys_context(self):
+        with self.assertRaises(Exception):
+            TableValidator.validate_statement(
+                "SELECT SYS_CONTEXT('USERENV', 'SESSION_USER') FROM dual")
+
+    def test_system_catalog_all_users(self):
+        """System catalog references should raise TableValidationError (403)."""
+        with self.assertRaises(TableValidationError):
+            TableValidator.validate_statement("SELECT * FROM ALL_USERS")
+
+    def test_system_catalog_dba_tables(self):
+        with self.assertRaises(TableValidationError):
+            TableValidator.validate_statement(
+                "SELECT * FROM ps UNION ALL SELECT table_name, 1 FROM DBA_TABLES")
+
+    def test_system_catalog_v_session(self):
+        with self.assertRaises(TableValidationError):
+            TableValidator.validate_statement("SELECT * FROM V$SESSION")
+
+    def test_word_boundary_no_false_positive(self):
+        """Keywords inside longer words should not trigger rejection."""
+        TableValidator.validate_statement(
+            "SELECT updated, created, dataset FROM ps")
+
+    def test_case_insensitive_rejection(self):
+        with self.assertRaises(Exception):
+            TableValidator.validate_statement("select * from ps; drop table ps")
+        with self.assertRaises(Exception):
+            TableValidator.validate_statement("Insert Into ps values (1)")
+
+
+class TestTableNames(unittest.TestCase):
+    """Tests for TableNames.extract_tables() parsing changes."""
+
+    def setUp(self):
+        from TAP.tablenames import TableNames
+        self.tn = TableNames()
+
+    def test_simple_select(self):
+        tables = self.tn.extract_tables("SELECT ra, dec FROM ps")
+        self.assertEqual(tables, ['ps'])
+
+    def test_multi_table_join(self):
+        tables = self.tn.extract_tables(
+            "SELECT a.ra FROM ps a, stellarhosts b WHERE a.id = b.id")
+        self.assertIn('ps', tables)
+        self.assertIn('stellarhosts', tables)
+
+    def test_order_by_not_extracted(self):
+        """ORDER BY columns should not appear as table names (StopIteration fix)."""
+        tables = self.tn.extract_tables(
+            "SELECT ra, dec FROM ps ORDER BY ra DESC")
+        self.assertEqual(tables, ['ps'])
+        self.assertNotIn('ra', tables)
+
+    def test_group_by_not_extracted(self):
+        tables = self.tn.extract_tables(
+            "SELECT dec, count(*) FROM ps GROUP BY dec")
+        self.assertEqual(tables, ['ps'])
+        self.assertNotIn('dec', tables)
+
+    def test_oracle_rownum_not_skipped(self):
+        """Oracle-dialect queries (ROWNUM) should still extract tables."""
+        tables = self.tn.extract_tables(
+            "SELECT * FROM ps WHERE ROWNUM <= 10")
+        self.assertIn('ps', tables)
+
+    def test_dml_skipped(self):
+        """DML statements should be skipped, returning no tables."""
+        tables = self.tn.extract_tables("INSERT INTO ps VALUES (1, 2)")
+        self.assertEqual(tables, [])
+
+    def test_ddl_skipped(self):
+        tables = self.tn.extract_tables("DROP TABLE ps")
+        self.assertEqual(tables, [])
+
+    def test_schema_qualified_table(self):
+        tables = self.tn.extract_tables(
+            "SELECT * FROM tap_schema.columns")
+        self.assertIn('tap_schema.columns', tables)
+
+    def test_case_insensitive_extraction(self):
+        tables = self.tn.extract_tables("SELECT * FROM PS")
+        self.assertEqual(tables, ['ps'])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Security hardening for the nexsciTAP query pipeline. Adds defense-in-depth validation at two layers: pre-connection statement screening and typed HTTP error responses.

Tested on vmkoatest with the full PyKOA DEIMOS tutorial notebook (14 query types, downloads, proprietary access) and internal A/B comparison notebook verifying correct 400 vs 403 error differentiation.

## Changes

- **Pre-connection statement validation** — new `validate_statement()` in `tablevalidator.py` rejects malformed or dangerous queries before any database connection is made, including DML/DDL injection, statement stacking, and dangerous function calls
- **Typed error responses** — new `TableValidationError` exception returns HTTP 403 for access denials instead of generic 400; startup failures return VOTable-wrapped 500 instead of raw text
- **Table name extraction fix** — Oracle-dialect queries no longer bypass table validation
- **Test coverage** — tightened assertions to catch regressions back to generic exception types