### PR TITLE
Bump version to 3.0.0 for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 ##### [Documentation](https://caltech-ipac.github.io/nexsciTAP)
 
-## NASA Exoplanet Science Institute (NExScI) Python Table Access Protocol (TAP) Server   Version 1.0
+## NASA Exoplanet Science Institute (NExScI) Python Table Access Protocol (TAP) Server
 
 The TAP (Table Access Protocol) is a standard recommended by the International Virtual Observatory Alliance (http://www.ivoa.net).  It defines a web service for searching tables in relational databases using a dialect of SQL called ADQL (Astronomical Data Query Language) (http://www.ivoa.net/documents/latest/ADQL.html).  ADQL includes functions that support spatial constraints (<i>e.g.,</i> all records with a degree on the sky of specified coordinates). 
 
 This TAP implementation is written as a Python package and can be installed through PyPI ("pip install") or built from the source in GitHub.  The distribution includes a module dedicated to translating ADQL to SQL and a spatial indexing package that improves the performance of spatial searches. The code base is compact. It consists of 10 KLOC of Python, and 15 KLOC of spatial indexing code, written in C and deployed as a Python binary extension package. 
 
-Because there are differences in the implementation of the SQL standard from DBMS to DBMS, we document how to use DB API 2.0 to implement the variants of SQL in common use. Version 1.0 of the TAP server supports Oracle and SQLite3.  It runs on LINUX and requires a a web server such as Apache, a C compiler, and deployment of either an Oracle server or the SQLite3 library.
+Because there are differences in the implementation of the SQL standard from DBMS to DBMS, we document how to use DB API 2.0 to implement the variants of SQL in common use. The TAP server supports Oracle, PostgreSQL, MySQL, and SQLite3.  It runs on LINUX and requires a web server such as Apache, a C compiler, and deployment of a supported database server (or the SQLite3 library).
 
-Several AQDL geometry functions are not deployed in Version 1.0. These are 
+Several ADQL geometry functions are not yet deployed. These are 
 
 INTERSECTS;  AREA and CENTROID;  COORD1, COORD2, and COORDSYS; and REGION.
 

--- a/Sphinx/conf.py
+++ b/Sphinx/conf.py
@@ -24,7 +24,7 @@ copyright = '2020, NExScI / IPAC / Caltech'
 author = 'John Good'
 
 # The full version, including alpha/beta/rc tags
-release = '1.1.3'
+release = '3.0.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from distutils.extension import Extension
 
 setup(name='nexsciTAP', 
-    version='3.0', 
+    version='3.0.0',
     author='John Good', 
     author_email='jcg@caltech.edu', 
     license='LICENSE', 


### PR DESCRIPTION
Version-bump-only PR in preparation for cutting the v3.0.0 GitHub Release.

## Changes
- \`setup.py\`: \`'3.0'\` → \`'3.0.0'\` (formal semver matching the tag)
- \`Sphinx/conf.py\`: \`'1.1.3'\` → \`'3.0.0'\` (was stale; docs site rebuilds from this)
- \`README.md\`: drop the inline "Version 1.0" mentions and update the supported-DBMS list (Oracle/PostgreSQL/MySQL/SQLite3, not just Oracle/SQLite3) so the README doesn't rot again

## Verified
- Wheel builds cleanly: \`nexscitap-3.0.0-cp311-cp311-macosx_11_0_arm64.whl\`

## Next steps after merge
- Tag \`v3.0.0\` at the merge commit
- Create the GitHub Release with the notes drafted alongside this work

🤖 Generated with [Claude Code](https://claude.com/claude-code)